### PR TITLE
Function calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,10 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "longleaf"
 version = "0.1.0"
 dependencies = [
- "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -62,11 +67,6 @@ dependencies = [
 [[package]]
 name = "maplit"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "once_cell"
-version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -173,8 +173,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e4fb201c5c22a55d8b24fef95f78be52738e5e1361129be1b5e862ecdb6894a"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
 name = "longleaf"
 version = "0.1.0"
 dependencies = [
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -61,6 +62,11 @@ dependencies = [
 [[package]]
 name = "maplit"
 version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "once_cell"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -168,6 +174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e4fb201c5c22a55d8b24fef95f78be52738e5e1361129be1b5e862ecdb6894a"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,8 @@ edition = "2018"
 pest = "2.1.2"
 pest_derive = "2.1.0"
 once_cell = "1.2.0"
+
+[features]
+default = []
+
+timing = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 pest = "2.1.2"
 pest_derive = "2.1.0"
+once_cell = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 pest = "2.1.2"
 pest_derive = "2.1.0"
-once_cell = "1.2.0"
+lazy_static = "1.4.0"
 
 [features]
 default = []

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,23 @@
+macro_rules! timed {
+    ($to_eval:expr) => {{
+        #[cfg(feature = "timing")]
+        {
+            use std::time::Instant;
+
+            let start = Instant::now();
+
+            let out = $to_eval;
+
+            let dur = start.elapsed();
+
+            println!("Took {} ms", dur.as_millis());
+
+            out
+        }
+        
+        #[cfg(not(feature = "timing"))]
+        {
+            $to_eval
+        }
+    }};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,7 +14,7 @@ macro_rules! timed {
 
             out
         }
-        
+
         #[cfg(not(feature = "timing"))]
         {
             $to_eval

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate pest_derive;
 
+#[macro_use]
+extern crate lazy_static;
+
 use std::io::{self, prelude::*};
 
 mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,9 @@ use std::io::{self, prelude::*};
 mod parser;
 mod vm;
 
+#[macro_use]
+mod macros;
+
 use parser::ReplInput;
 use vm::VM;
 
@@ -31,7 +34,7 @@ fn main() {
                 print_quit_dialogue();
                 break 'main_loop;
             }
-            Ok(ReplInput::VarDefn(name, expr_node)) => match vm.evaluate_expr(expr_node) {
+            Ok(ReplInput::VarDefn(name, expr_node)) => match timed!(vm.evaluate_expr(expr_node)) {
                 Ok(val) => {
                     let def_result = vm.define_variable(&name, val);
                     if let Err(e) = def_result {
@@ -42,7 +45,7 @@ fn main() {
                     println!("Error evaluating expression: {:?}", e);
                 }
             },
-            Ok(ReplInput::Expr(expr_node)) => match vm.evaluate_expr(expr_node) {
+            Ok(ReplInput::Expr(expr_node)) => match timed!(vm.evaluate_expr(expr_node)) {
                 Ok(val) => {
                     println!("{:?}", val);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,10 @@ fn main() {
             }
             Ok(ReplInput::VarDefn(name, expr_node)) => match vm.evaluate_expr(expr_node) {
                 Ok(val) => {
-                    vm.define_variable(&name, val);
+                    let def_result = vm.define_variable(&name, val);
+                    if let Err(e) = def_result {
+                        println!("Error defining variable {}: {:?}", name, e);
+                    }
                 }
                 Err(e) => {
                     println!("Error evaluating expression: {:?}", e);

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -32,7 +32,13 @@ unary_expr =
     | unary_op ~ unary_expr
     }
 
-base_expr = { paren_expr | id | float | float_list }
+base_expr = { paren_expr | function_call | id | float | float_list }
+
+function_call =
+    { id ~ "(" ~ ")"
+    | id ~ "(" ~ expr ~ ( "," ~ expr )* ~ ( "," )? ~ ")"
+    }
+
 paren_expr = { "(" ~ expr ~ ")" }
 
 add_op = { PLUS | MINUS }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -64,6 +64,45 @@ fn to_expr_tests() {
             )),
         ),
     );
+
+    do_test(
+        "f(1, 2, 3+4)",
+        FunctionCall(
+            "f".to_string(),
+            vec![
+                Float(1.),
+                Float(2.),
+                BinaryExpr(Plus, Box::new(Float(3.)), Box::new(Float(4.))),
+            ],
+        ),
+    );
+
+    do_test(
+        "sin(x)",
+        FunctionCall("sin".to_string(), vec![VariableRef("x".to_string())]),
+    );
+
+    do_test(
+        "-cos(12+f(x)-1)",
+        UnaryExpr(
+            Negate,
+            Box::new(FunctionCall(
+                "cos".to_string(),
+                vec![BinaryExpr(
+                    Plus,
+                    Box::new(Float(12.)),
+                    Box::new(BinaryExpr(
+                        Minus,
+                        Box::new(FunctionCall(
+                            "f".to_string(),
+                            vec![VariableRef("x".to_string())],
+                        )),
+                        Box::new(Float(1.)),
+                    )),
+                )],
+            )),
+        ),
+    );
 }
 
 fn to_float_list(s: &str) -> ParseResult<Vec<f64>> {

--- a/src/vm/macros.rs
+++ b/src/vm/macros.rs
@@ -1,3 +1,33 @@
+macro_rules! unary_fn_switcher {
+    ($func:expr, $a:expr, $store:expr) => {{
+        let a: EvalValue = $a;
+        let func = $func;
+
+        match a {
+            EvalValue::Float(a) => EvalValue::Float(func(a)),
+            EvalValue::FloatList(a) => EvalValue::FloatList(unary_fn_vector!(func, a, $store)),
+        }
+    }};
+}
+
+macro_rules! unary_fn_vector {
+    ($func:expr, $a:expr, $store:expr) => {{
+        let a: Box<dyn FloatListValue> = $a;
+        let a: &Vec<f64> = &**a; // TODO: for real?
+
+        let func = $func;
+
+        let mut out = ($store).get_vector(a.len());
+        assert_eq!(out.len(), a.len());
+
+        for i in 0..a.len() {
+            out[i] = func(a[i]);
+        }
+
+        Box::new(out)
+    }};
+}
+
 macro_rules! unary_switcher {
     ($op:tt, $a:expr, $store:expr) => {
         {
@@ -5,13 +35,13 @@ macro_rules! unary_switcher {
 
             match a {
                 EvalValue::Float(a) => EvalValue::Float($op a),
-                EvalValue::FloatList(a) => EvalValue::FloatList(vector!($op, a, $store)),
+                EvalValue::FloatList(a) => EvalValue::FloatList(unary_op_vector!($op, a, $store)),
             }
         }
     }
 }
 
-macro_rules! vector {
+macro_rules! unary_op_vector {
     ($op:tt, $a:expr, $store:expr) => {
         {
             let a: Box<dyn FloatListValue> = $a;

--- a/src/vm/store.rs
+++ b/src/vm/store.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::rc::{Rc, Weak};
 
-use super::FloatListValue;
+use super::{EvalValue, FloatListValue};
 
 pub struct VectorStore {
     internal_store: Rc<VectorInternalStore>,
@@ -68,6 +68,12 @@ impl VectorInternalStore {
 pub struct TrackedVector {
     data: Vec<f64>,
     home_store: Weak<VectorInternalStore>,
+}
+
+impl Into<EvalValue> for TrackedVector {
+    fn into(self) -> EvalValue {
+        EvalValue::FloatList(Box::new(self))
+    }
 }
 
 impl FloatListValue for TrackedVector {

--- a/src/vm/tests.rs
+++ b/src/vm/tests.rs
@@ -14,7 +14,7 @@ fn run_repl_inputs(input: &[&str], expected: Vec<EvalValue>) {
             }
             ReplInput::VarDefn(id, expr) => {
                 let val = vm.evaluate_expr(expr).unwrap();
-                vm.define_variable(&id, val);
+                vm.define_variable(&id, val).unwrap();
             }
             other => {
                 panic!("Expected executable input, got {:?}", other);

--- a/src/vm/tests.rs
+++ b/src/vm/tests.rs
@@ -53,3 +53,28 @@ fn var_tests() {
         vec![(vec![5., 27.]).into()],
     );
 }
+
+#[test]
+fn make_range_tests() {
+    fn do_range_test(start: f64, end: f64, step: f64, expected: Vec<f64>) {
+        let actual = make_range(start.into(), end.into(), step.into()).unwrap();
+
+        let expected: EvalValue = expected.into();
+
+        assert_eq!(actual, expected);
+    }
+
+    do_range_test(1., 2., 1., vec![1.]);
+    do_range_test(1., 2., 0.5, vec![1., 1.5]);
+
+    do_range_test(1., 1., 1., vec![]);
+
+    do_range_test(2., 1., -1., vec![2.]);
+    do_range_test(2., 1., -0.5, vec![2., 1.5]);
+    do_range_test(
+        2.,
+        1.,
+        -0.3,
+        vec![2., 2. - 0.3, 2. - 0.3 - 0.3, 2. - 0.3 - 0.3 - 0.3],
+    );
+}

--- a/src/vm/tests.rs
+++ b/src/vm/tests.rs
@@ -57,7 +57,9 @@ fn var_tests() {
 #[test]
 fn make_range_tests() {
     fn do_range_test(start: f64, end: f64, step: f64, expected: Vec<f64>) {
-        let actual = make_range(start.into(), end.into(), step.into()).unwrap();
+        let store = VectorStore::new();
+
+        let actual = make_range(start.into(), end.into(), step.into(), &store).unwrap();
 
         let expected: EvalValue = expected.into();
 


### PR DESCRIPTION
Resolve #11 

Added sin/cos/tan functions which you can call (vectorized)
Added range function -- `range(start, end, step)` which returns a vector (the only reasonable way to make a large vector for now)

Added a timing feature; now when you call a big eval in the REPL it prints out the ms required to execute it, which is nice.

Looks like we're slower than numpy for now, which is RIDICULOUS because I have worked on this for TWO DAYS and that should easily be enough to outperform a major industry product

EDIT: looks like we're comparable with numpy, which makes more sense (how do you speed up vector addition, for real? It's just a loop.)